### PR TITLE
Turn all tool calls into go routine on unbuffured channels

### DIFF
--- a/examples/composio-github-star/main.go
+++ b/examples/composio-github-star/main.go
@@ -1,6 +1,3 @@
-// Package main is an example of using the composio client.
-//
-// It shows how to use the composio client to star a github repository.
 package main
 
 import (
@@ -72,10 +69,25 @@ Star the repo conneroisu/groq-go on GitHub.
 	if err != nil {
 		return err
 	}
-	resp, err := comp.Run(ctx, user[0], chat)
-	if err != nil {
+
+	resultChan := make(chan []groq.ChatCompletionMessage)
+	errChan := make(chan error)
+
+	go func() {
+		resp, err := comp.Run(ctx, user[0], chat)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		resultChan <- resp
+	}()
+
+	select {
+	case resp := <-resultChan:
+		fmt.Println(resp)
+	case err := <-errChan:
 		return err
 	}
-	fmt.Println(resp)
+
 	return nil
 }


### PR DESCRIPTION
Convert tool calls to asynchronous execution using goroutines and unbuffered channels.

* **`examples/composio-github-star/main.go`**
  - Add unbuffered channels for `comp.Run` tool call.
  - Execute `comp.Run` tool call in a goroutine.
  - Receive the result from the unbuffered channel.

* **`examples/e2b-go-project/main.go`**
  - Add unbuffered channels for `sb.RunTooling` tool call.
  - Execute `sb.RunTooling` tool call in a goroutine.
  - Receive the result from the unbuffered channel.

* **`examples/toolhouse-python-code-interpreter/main.go`**
  - Add unbuffered channels for `ext.Run` tool call.
  - Execute `ext.Run` tool call in a goroutine.
  - Receive the result from the unbuffered channel.

* **`extensions/composio/run.go`**
  - Add unbuffered channels for `comp.Run` tool call.
  - Execute `comp.Run` tool call in a goroutine.
  - Receive the result from the unbuffered channel.

